### PR TITLE
[Codex] Add markdown preview to editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "gitnote",
       "version": "0.1.0",
       "dependencies": {
+        "marked": "^11.2.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "yjs": "^13.6.18"
@@ -847,6 +848,18 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/marked": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-11.2.0.tgz",
+      "integrity": "sha512-HR0m3bvu0jAPYiIvLUUQtdg1g6D247//lvcekpHO1WMvbwDlwSkZAX9Lw4F4YHE1T0HaaNve0tuAWuV1UJ6vtw==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/nanoid": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "marked": "^11.2.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "yjs": "^13.6.18"

--- a/src/styles.css
+++ b/src/styles.css
@@ -21,11 +21,27 @@ body { background: var(--bg); color: var(--text); font: 14px/1.4 system-ui, sans
 .note-list { display:flex; flex-direction:column; gap:6px; margin-top:10px; }
 .note-item { padding:6px 8px; border:1px solid var(--border); border-radius:6px; cursor:pointer; }
 .note-item.active { border-color: var(--accent); }
-.editor { flex:1; padding: 12px; }
-.editor textarea { width:100%; height:100%; background:#0d1017; color:var(--text); border:1px solid var(--border); border-radius:8px; padding:12px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace; font-size: 14px; }
+.editor { flex:1; padding:12px; display:flex; gap:12px; }
+.editor textarea,
+.editor .preview {
+  flex:1;
+  background:#0d1017;
+  color:var(--text);
+  border:1px solid var(--border);
+  border-radius:8px;
+  padding:12px;
+}
+.editor textarea {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size:14px;
+}
+.editor .preview {
+  overflow:auto;
+}
 
 @media (max-width: 800px) {
   .app { grid-template-columns: 1fr; }
   .sidebar { display:none; }
+  .editor { flex-direction:column; }
 }
 

--- a/src/ui/Editor.tsx
+++ b/src/ui/Editor.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import * as Y from 'yjs';
+import { marked } from 'marked';
 import type { NoteDoc } from '../storage/local';
 
 interface Props {
@@ -38,12 +39,17 @@ export function Editor({ doc, onChange }: Props) {
     });
   };
 
+  const html = useMemo(() => marked.parse(text), [text]);
+
   return (
-    <textarea
-      value={text}
-      onChange={(e) => onInput(e.target.value)}
-      spellCheck={false}
-    />
+    <>
+      <textarea
+        value={text}
+        onChange={(e) => onInput(e.target.value)}
+        spellCheck={false}
+      />
+      <div className="preview" dangerouslySetInnerHTML={{ __html: html }} />
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- add `marked` dependency to render markdown
- introduce live preview alongside editor
- improve editor styles for side-by-side layout

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c443ccafe48323b061fd31c849c536