### PR TITLE
[Codex] Enable GitHub OAuth and remote sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 node_modules/
 dist/
+.env
 .DS_Store
+tsconfig.tsbuildinfo
 

--- a/src/auth/github.ts
+++ b/src/auth/github.ts
@@ -1,0 +1,85 @@
+/// <reference types="vite/client" />
+// GitHub OAuth device flow helper functions.
+// Uses GitHub's device authorization to obtain an access token without a server.
+
+// Vite exposes env vars via import.meta.env
+const CLIENT_ID = import.meta.env.VITE_GITHUB_CLIENT_ID as string;
+
+interface DeviceCodeResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  expires_in: number;
+  interval: number;
+}
+
+interface TokenResponse {
+  access_token?: string;
+  error?: string;
+}
+
+async function requestDeviceCode(): Promise<DeviceCodeResponse> {
+  const res = await fetch('https://github.com/login/device/code', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify({
+      client_id: CLIENT_ID,
+      scope: 'repo',
+    }),
+  });
+  if (!res.ok) throw new Error('Failed to request device code');
+  return (await res.json()) as DeviceCodeResponse;
+}
+
+async function pollForToken(device: DeviceCodeResponse): Promise<string | null> {
+  const start = Date.now();
+  while (Date.now() - start < device.expires_in * 1000) {
+    await new Promise((r) => setTimeout(r, device.interval * 1000));
+    const res = await fetch('https://github.com/login/oauth/access_token', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({
+        client_id: CLIENT_ID,
+        device_code: device.device_code,
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+      }),
+    });
+    const data = (await res.json()) as TokenResponse;
+    if (data.access_token) return data.access_token;
+    if (data.error === 'authorization_pending') continue;
+    if (data.error) throw new Error(data.error);
+  }
+  return null;
+}
+
+export async function connectToGitHub(): Promise<string | null> {
+  if (!CLIENT_ID) {
+    alert('GitHub client id not configured');
+    return null;
+  }
+  const device = await requestDeviceCode();
+  // Open verification URL and instruct the user to enter the code
+  window.open(device.verification_uri, '_blank');
+  alert(`Authorize GitNote in the opened window. When prompted, enter code: ${device.user_code}`);
+  try {
+    const token = await pollForToken(device);
+    if (token) {
+      localStorage.setItem('gitnote:gh-token', token);
+    }
+    return token;
+  } catch (err) {
+    console.error(err);
+    alert('GitHub authorization failed');
+    return null;
+  }
+}
+
+export function getStoredToken(): string | null {
+  return localStorage.getItem('gitnote:gh-token');
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -24,6 +24,9 @@ body { background: var(--bg); color: var(--text); font: 14px/1.4 system-ui, sans
 .editor { flex:1; padding: 12px; }
 .editor textarea { width:100%; height:100%; background:#0d1017; color:var(--text); border:1px solid var(--border); border-radius:8px; padding:12px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace; font-size: 14px; }
 
+.modal-backdrop { position:fixed; inset:0; background:rgba(0,0,0,0.5); display:flex; align-items:center; justify-content:center; }
+.modal { background:var(--panel); border:1px solid var(--border); border-radius:8px; padding:20px; display:flex; flex-direction:column; gap:10px; min-width:260px; }
+
 @media (max-width: 800px) {
   .app { grid-template-columns: 1fr; }
   .sidebar { display:none; }

--- a/src/sync/git-sync.ts
+++ b/src/sync/git-sync.ts
@@ -1,12 +1,12 @@
-// Placeholder Git sync API using GitHub REST v3.
-// Implementations should authenticate via a personal token kept in localStorage (MVP)
-// and operate on repo contents endpoints.
+// Git sync helpers backed by GitHub's REST v3 API.
+// Uses a stored OAuth token to read and write note files in a repository.
+
+import { getStoredToken } from '../auth/github';
 
 export interface RemoteConfig {
   owner: string;
   repo: string;
   branch: string;
-  token: string;
   notesDir: string; // e.g., 'notes'
 }
 
@@ -16,26 +16,64 @@ export interface RemoteFile {
   sha: string; // blob sha at HEAD
 }
 
-let remote: RemoteConfig | null = null;
+let remote: RemoteConfig | null = loadConfig();
+
+function loadConfig(): RemoteConfig | null {
+  const raw = localStorage.getItem('gitnote:config');
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as RemoteConfig;
+  } catch {
+    return null;
+  }
+}
 
 export function configureRemote(cfg: RemoteConfig) {
   remote = cfg;
+  localStorage.setItem('gitnote:config', JSON.stringify(cfg));
+}
+
+function authHeaders() {
+  const token = getStoredToken();
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+  };
 }
 
 export async function pullNote(path: string): Promise<RemoteFile | null> {
   if (!remote) return null;
-  // TODO: GET /repos/{owner}/{repo}/contents/{path}?ref={branch}
-  // decode base64 content -> text, capture sha
-  return null;
+  const url = `https://api.github.com/repos/${remote.owner}/${remote.repo}/contents/${path}?ref=${remote.branch}`;
+  const res = await fetch(url, { headers: authHeaders() });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error('Failed to fetch note');
+  const data = await res.json();
+  const content = atob((data.content as string).replace(/\n/g, ''));
+  return { path, text: content, sha: data.sha };
 }
 
 export async function commitBatch(
   files: { path: string; text: string; baseSha?: string }[],
   message: string
 ): Promise<string | null> {
-  if (!remote) return null;
-  // TODO: Either multiple PUT /contents/<path> commits or a single tree+commit API usage
-  // For MVP, a loop with PUT contents is acceptable.
-  return null;
+  if (!remote || files.length === 0) return null;
+  let commitSha: string | null = null;
+  for (const f of files) {
+    const url = `https://api.github.com/repos/${remote.owner}/${remote.repo}/contents/${f.path}`;
+    const res = await fetch(url, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
+      body: JSON.stringify({
+        message,
+        content: btoa(f.text),
+        sha: f.baseSha,
+        branch: remote.branch,
+      }),
+    });
+    if (!res.ok) throw new Error('Commit failed');
+    const data = await res.json();
+    commitSha = data.commit?.sha || commitSha;
+  }
+  return commitSha;
 }
 

--- a/src/ui/RepoConfigModal.tsx
+++ b/src/ui/RepoConfigModal.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+
+interface Props {
+  onSubmit: (cfg: { owner: string; repo: string; branch: string }) => void;
+  onCancel: () => void;
+}
+
+export function RepoConfigModal({ onSubmit, onCancel }: Props) {
+  const [owner, setOwner] = useState('');
+  const [repo, setRepo] = useState('');
+  const [branch, setBranch] = useState('main');
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!owner.trim() || !repo.trim()) return;
+    onSubmit({ owner: owner.trim(), repo: repo.trim(), branch: branch.trim() });
+  };
+
+  return (
+    <div className="modal-backdrop">
+      <form className="modal" onSubmit={submit}>
+        <h3>Configure Repository</h3>
+        <input
+          className="input"
+          placeholder="Owner"
+          value={owner}
+          onChange={(e) => setOwner(e.target.value)}
+          required
+        />
+        <input
+          className="input"
+          placeholder="Repository"
+          value={repo}
+          onChange={(e) => setRepo(e.target.value)}
+          required
+        />
+        <input
+          className="input"
+          placeholder="Branch"
+          value={branch}
+          onChange={(e) => setBranch(e.target.value)}
+        />
+        <div className="toolbar" style={{ justifyContent: 'flex-end' }}>
+          <button type="submit" className="btn primary">Save</button>
+          <button type="button" className="btn" onClick={onCancel}>Cancel</button>
+        </div>
+      </form>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- replace prompt-based GitHub repo configuration with a modal dialog and validation
- style modal and ignore .env files

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c443b3337083239b553e1a7d34365f